### PR TITLE
Windows-related patches, and a couple util patches

### DIFF
--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -16,6 +16,7 @@ endfunction
 
 
 function! Do_You_Own(filename)
+    echom "Request for " . a:filename
     return bufloaded(a:filename)
 endfunction
 
@@ -40,13 +41,14 @@ function! Remote_Open(filename, command)
         call foreground()
     endif 
 
-    let s:in_remote_open = 1
+    let s:in_remote_open = 0
     return "Server " . v:servername . " opened file " . a:filename
 endfunction
 
 function! Buf_Enter()
     if s:buffer_to_cleanup != ""
         echom "Cleaning up " . s:buffer_to_cleanup
+        bp
         execute "bdelete " . s:buffer_to_cleanup
         let s:buffer_to_cleanup = ""
     endif
@@ -62,14 +64,14 @@ function! Swap_Exists()
 
     let owning_server = ""
     for server in s:other_servers()
-        if remote_expr(server, 'Do_You_Own("' . expand("<afile>") . '")') != "0"
+        if remote_expr(server, "Do_You_Own('" . expand("<afile>") . "')") != "0"
             let owning_server = server
             break
         endif
     endfor
 
     let swapcommand = substitute(v:swapcommand, "\r", "", "g")
-    let remexpr = 'Remote_Open("' . expand("<afile>") . '", "' . swapcommand . '")'
+    let remexpr = "Remote_Open('" . expand("<afile>") . "', '" . swapcommand . "')"
 
     if has('win32') 
         call remote_foreground(owning_server)

--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -71,10 +71,11 @@ function! Swap_Exists()
     let swapcommand = substitute(v:swapcommand, "\r", "", "g")
     let remexpr = 'Remote_Open("' . expand("<afile>") . '", "' . swapcommand . '")'
 
-    echom remote_expr(owning_server, remexpr)
     if has('win32') 
         call remote_foreground(owning_server)
     endif 
+
+    echom remote_expr(owning_server, remexpr)
     " Cleanup the buffer to avoid dangling entries
     let s:buffer_to_cleanup = expand("<afile>")
 

--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -36,7 +36,9 @@ function! Remote_Open(filename, command)
 
     " Take focus on the new window
     echom "Taking focus"
-    call foreground()
+    if !has('win32')
+        call foreground()
+    endif 
 
     let s:in_remote_open = 1
     return "Server " . v:servername . " opened file " . a:filename
@@ -70,7 +72,9 @@ function! Swap_Exists()
     let remexpr = 'Remote_Open("' . expand("<afile>") . '", "' . swapcommand . '")'
 
     echom remote_expr(owning_server, remexpr)
-
+    if has('win32') 
+        call remote_foreground(owning_server)
+    endif 
     " Cleanup the buffer to avoid dangling entries
     let s:buffer_to_cleanup = expand("<afile>")
 

--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -16,7 +16,6 @@ endfunction
 
 
 function! Do_You_Own(filename)
-    echom "Request for " . a:filename
     return bufloaded(a:filename)
 endfunction
 

--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -36,9 +36,8 @@ function! Remote_Open(filename, command)
 
     " Take focus on the new window
     echom "Taking focus"
-    if !has('win32')
-        call foreground()
-    endif 
+    call foreground()
+ 
 
     let s:in_remote_open = 0
     return "Server " . v:servername . " opened file " . a:filename


### PR DESCRIPTION
Problems (theoretically) fixed:

* Opening a file from NERDTree that exists on a different server destroys the NERDTree buffer and breaks `:NERDTreeToggle`. If relevant, closes splits (including intended persistent ones)
    * Patch: Call `bp` before deleting the buffer (https://stackoverflow.com/a/4403691). 
* Doesn't work with deep paths (`SomeFile.txt` is fine, `D:\some\path\SomeFile.txt` is not) - Windows only
    * Patch: Flipping quotes (https://stackoverflow.com/a/32067073)
* Window change doesn't doesn't focus on Windows 
    * Patch: Call `remote_foreground()` instead of `foreground()` on Windows. See `:help foreground()`: "On Win32 systems this might not work, the OS does not always allow a window to bring itself to the foreground.". `remote_foreground()` (`:help remote_foreground()`) is called on Windows because it brings focus to a non-minimized window. From my testing, both are required. Gotta love Windows.
* The script some times claims there's a recursive swap when there isn't 
    * Patch: flip `s:in_remote_open` to 0 instead of 1 on line 43 (previously line 41). Might be a typo?


