### PR TITLE
Fix issue with dangling swap files

### DIFF
--- a/plugin/multimonitor.vim
+++ b/plugin/multimonitor.vim
@@ -68,6 +68,19 @@ function! Swap_Exists()
         endif
     endfor
 
+    " If finding the server fails, abort this process. 
+    " The swap file may legitimately need to be recovered, but this lets
+    " the user get control of what happens with the swap file.
+    " This shouldn't happen unless a bug preserves a swap file, or Vim is
+    " forcibly closed as a result of an OS-level halt. For an instance, if the
+    " computer randomly decides to update while there's unsaved files, if
+    " there's a power outage or the computer otherwise loses power, or if
+    " there's an accident that causes Vim to be force closed in a way that
+    " doesn't properly handle buffers and clear swap files. 
+    if owning_server == ""
+        return
+    endif
+
     let swapcommand = substitute(v:swapcommand, "\r", "", "g")
     let remexpr = "Remote_Open('" . expand("<afile>") . "', '" . swapcommand . "')"
 


### PR DESCRIPTION
This fixes an issue where an instance of Vim, for whatever reason, is closed and leaves behind a swap file. This mainly happens if the editor is force-closed, but there's proabably more explanations. These swap files may contain content worth recovering, but it also blocks that file from being edited entirely. The previous version assumed it existed, which isn't always the case. 

This PR mitigates that with a single try-catch to see if the remote is set to the default value or not. If it is, it returns and lets the built-in swap flow continue as normal.